### PR TITLE
prevent xss injection

### DIFF
--- a/helpers/SolrSearch_Helpers_Facet.php
+++ b/helpers/SolrSearch_Helpers_Facet.php
@@ -31,7 +31,7 @@ class SolrSearch_Helpers_Facet
 
             // Collapse into an array of pairs.
             foreach ($matches['field'] as $i => $field) {
-                $facets[] = array($field, $matches['value'][$i]);
+                $facets[] = array($field, htmlspecialchars(strip_tags($matches['value'][$i])));
             }
 
         }


### PR DESCRIPTION
We recently noticed a xss attempt using the following url:
`solr-search?q=&facet=itemtype:%22New%3Cimg%20src=x%20onerror=alert(document.domain)%3E%22`

They used inline javascript in a img-tag in the facet part of the query url.

These facet values aren't sanitized at the moment and are being displayed here:
https://github.com/biblibre/omeka-plugin-SolrSearch/blob/bf1e4b2403d1d998854427e31ebc73ecc7e4d9e4/views/shared/results/index.php#L45

This pr adds adds htmlspecialchars and strip_tags to sanitize the facet values in the function parseFacets